### PR TITLE
Fix TypeError in TrainingArguments parameter

### DIFF
--- a/notebooks/train-codebert.ipynb
+++ b/notebooks/train-codebert.ipynb
@@ -708,7 +708,7 @@
     "    weight_decay=WEIGHT_DECAY,\n",
     "    learning_rate=LEARNING_RATE,\n",
     "    gradient_accumulation_steps=GRADIENT_ACCUMULATION_STEPS,\n",
-    "    evaluation_strategy=\"epoch\",\n",
+    "    eval_strategy=\"epoch\",  # Changed from evaluation_strategy to eval_strategy\n",
     "    save_strategy=\"epoch\",\n",
     "    load_best_model_at_end=True,\n",
     "    metric_for_best_model=\"f1\",\n",


### PR DESCRIPTION
This PR fixes the TypeError: TrainingArguments.__init__() got an unexpected keyword argument "evaluation_strategy" issue in the train-codebert notebook.

Changes made:
- Changed "evaluation_strategy" to "eval_strategy" in the TrainingArguments constructor to match the current transformers library API (version 4.51.3)

This change ensures the notebook can run without the TypeError while maintaining the original logic and functionality.