### PR TITLE
Fix compute_loss method to accept num_items_in_batch parameter

### DIFF
--- a/notebooks/train-codebert.ipynb
+++ b/notebooks/train-codebert.ipynb
@@ -687,7 +687,8 @@
    "source": [
     "# Create a custom loss function with class weights\n",
     "class WeightedLossTrainer(Trainer):\n",
-    "    def compute_loss(self, model, inputs, return_outputs=False):\n",
+    "    def compute_loss(self, model, inputs, return_outputs=False, **kwargs):\n",
+    "        # Added **kwargs to accept additional parameters like num_items_in_batch\n",
     "        labels = inputs.pop(\"labels\")\n",
     "        outputs = model(**inputs)\n",
     "        logits = outputs.logits\n",


### PR DESCRIPTION
This PR fixes the TypeError issue in the train-codebert notebook by modifying the compute_loss method in the WeightedLossTrainer class to accept the num_items_in_batch parameter. The error occurred because the Transformers library passes this parameter to the compute_loss method, but our custom implementation did not accept it. By adding **kwargs to the method signature, we can now handle this parameter without changing the core functionality.