### PR TITLE
Fix import error in CodeBERT notebook

### DIFF
--- a/notebooks/full-codebert-train-fixed.ipynb
+++ b/notebooks/full-codebert-train-fixed.ipynb
@@ -60,7 +60,8 @@
     "# Import our custom trainer module\n",
     "import sys\n",
     "sys.path.append('..')\n",
-    "from notebooks.codebert_trainer import get_trainer, monitor_resources, cleanup_memory\n",
+    "# Import directly from the local file instead of as a package\n",
+    "from codebert_trainer import get_trainer, monitor_resources, cleanup_memory\n",
     "\n",
     "# Set a seed for reproducibility\n",
     "set_seed(42)"


### PR DESCRIPTION
## Description
This PR fixes the ModuleNotFoundError in the `notebooks/full-codebert-train-fixed.ipynb` file.

## Changes Made
- Modified the import statement from `from notebooks.codebert_trainer import ...` to `from codebert_trainer import ...`

## Issue Fixed
The notebook was trying to import the codebert_trainer module as if it were in a package called "notebooks", but the file is actually located directly in the notebooks directory. This change fixes the import path to correctly reference the local file.

## Error Fixed
```
ModuleNotFoundError: No module named notebooks
```